### PR TITLE
Add composer.json - improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
 			"homepage":"http://hmn.md/"
 		}
 	],
+	"type": "wordpress-muplugin",
 	"require": {
 		"composer/installers": "~1.0"
 	 }


### PR DESCRIPTION
This PR builds on @Tarendai's work in #6 to add a valid, functional composer.json file to Mercator.

Changes I've made:
-   Fixed the description to use Mercator's description
-   Replaced two spaces with one tab character
-   Set the type to "wordpress-muplugin", so it gets installed to your mu-plugins folder
-   Added a comma that was missing
