### PR TITLE
Add plugin meta to mercator.php

### DIFF
--- a/mercator.php
+++ b/mercator.php
@@ -1,9 +1,13 @@
 <?php
 /**
- * Mercator
- *
- * WordPress multisite domain mapping for the modern era.
- *
+ * Plugin Name: Mercator
+ * Plugin URI: https://github.com/humanmade/Mercator
+ * Description: WordPress multisite domain mapping for the modern era.
+ * Version: 0.1
+ * Author: humanmade
+ * Author URI: https://github.com/humanmade
+ * License: GPLv2
+ * 
  * @package Mercator
  */
 


### PR DESCRIPTION
Added plugin meta so it will be identified by WP function get_plugins('/path/to/mu-plugins') (used by some mu-plugin autoloaders)