### PR TITLE
ADD plugin headers. Allows installation via Composer directly into MU-Plugins dir.

### DIFF
--- a/mercator.php
+++ b/mercator.php
@@ -7,6 +7,18 @@
  * @package Mercator
  */
 
+/*
+Plugin Name: Mercator
+Plugin URI: https://github.com/humanmade/Mercator
+Description: WordPress multisite domain mapping for the modern era.
+Version: 3.1.1
+Author: Human Made Limited
+Author URI: http://hmn.md/
+License: GPL-2.0+
+Text Domain: mercator
+Network: true
+*/
+
 namespace Mercator;
 
 use WP_CLI;


### PR DESCRIPTION
If using composer to deploy as a mu-plugin, then the files get installed into mu-plugins/mercator/ which means that by default WordPress won't know anything about it (As it's not in the root). However, there are several techniques to slap WP across the wrists and tell it to load MU-plugins from sub-directories within the MU-plugin folder. However, they rely on the plugins within them having plugin headers (because get_plugins() calls get_plugin_data() which needs those headers). Adding these plugin headers to Mercator allows this plugin to be installed as a MU-Plugin from composer directly if one of these methods is employed.

For reference: https://richardtape.com/2014/08/22/composer-and-wordpress-mu-plugins/