### PR TITLE
Change check_table

### DIFF
--- a/mercator.php
+++ b/mercator.php
@@ -189,7 +189,7 @@ function check_domain_mapping( $site, $domain ) {
 function check_table() {
 	global $wpdb;
 
-	if ( get_option( 'mercator.db.version' ) === VERSION ) {
+	if ( get_site_option( 'mercator.db.version' ) === VERSION ) {
 		return 'exists';
 	}
 
@@ -230,7 +230,7 @@ function check_table() {
 	maybe_convert_table_to_utf8mb4( $wpdb->dmtable );
 
 	// Update db version option.
-	update_option( 'mercator.db.version', VERSION );
+	update_site_option( 'mercator.db.version', VERSION );
 
 	return 'created';
 }


### PR DESCRIPTION
Currently the check_table function, will performance the delta on every site, as the check is on the local site's options. mercator.db.version should be stored network level. 