### PR TITLE
Use the current session token when setting the auth cookies

### DIFF
--- a/sso.php
+++ b/sso.php
@@ -471,6 +471,7 @@ function get_login_url( $user, $args ) {
 		'action' => ACTION_LOGIN,
 		'key'    => $key,
 		'nonce'  => create_shared_nonce( 'mercator-sso-login|' . $key ),
+		'token'  => wp_get_session_token(),
 	);
 	$admin_url = get_admin_url( $args['site'], 'admin-ajax.php', 'relative' );
 	$admin_url = add_query_arg( urlencode_deep( $url_args ), $admin_url );
@@ -554,7 +555,7 @@ function handle_login_response() {
 	}
 
 	wp_set_current_user( $token['user'] );
-	wp_set_auth_cookie( $token['user'], true );
+	wp_set_auth_cookie( $token['user'], true, '', $args['token'] );
 
 	// Logged in, return to sender.
 	wp_redirect( $token['back'] );


### PR DESCRIPTION
This PR uses the current session token when setting the auth cookies during SSO.

This fixes an issue when attempting to log out from the mapped domain. Currently, if you attempt to log out from the mapped domain, the SSO JS code kicks in again so you are immediately logged back in.

Fixes #14.