### PR TITLE
Switch from 'delete_blog' hook to 'wp_uninitialize_site'

### DIFF
--- a/mercator.php
+++ b/mercator.php
@@ -89,7 +89,7 @@ function startup() {
 	// Actually hook in!
 	add_filter( 'pre_get_site_by_path', __NAMESPACE__ . '\\check_domain_mapping', 10, 2 );
 	add_action( 'admin_init', __NAMESPACE__ . '\\load_admin', -100 );
-	add_action( 'delete_blog', __NAMESPACE__ . '\\clear_mappings_on_delete' );
+	add_action( 'wp_uninitialize_site', __NAMESPACE__ . '\\clear_mappings_on_delete' );
 	add_action( 'muplugins_loaded', __NAMESPACE__ . '\\register_mapped_filters', -10 );
 
 	// Add CLI commands
@@ -247,10 +247,10 @@ function load_admin() {
 /**
  * Clear mappings for a site when it's deleted
  *
- * @param int $site_id Site being deleted
+ * @param WP_Site $site Deleted site object.
  */
-function clear_mappings_on_delete( $site_id ) {
-	$mappings = Mapping::get_by_site( $site_id );
+function clear_mappings_on_delete( $site ) {
+	$mappings = Mapping::get_by_site( $site->id );
 
 	if ( empty( $mappings ) ) {
 		return;


### PR DESCRIPTION
`'delete_blog'` hook was deprecated in WordPress 5.1.0.

Fixes #108, #113.