### PR TITLE
SSO: When fetching the user, use 'EXISTS' for 'meta_compare' argument.

### DIFF
--- a/sso.php
+++ b/sso.php
@@ -504,11 +504,7 @@ function handle_login_response() {
 	// Fetch using the token
 	$users = get_users( array(
 		'meta_key'     => 'mercator_sso_' . $args['key'],
-
-		// Check that the value exists (WP doesn't support EXISTS, so use a
-		// dummy value that will never match)
-		'meta_value'   => 'dummy_value',
-		'meta_compare' => '!=',
+		'meta_compare' => 'EXISTS',
 
 		// Skip capability check
 		'blog_id'      => 0,


### PR DESCRIPTION
This PR removes `'meta_value' = 'dummy_value'` and replaces it with `'meta_compare' = 'EXISTS'` in the user token lookup, since `EXISTS` is now supported in `get_users()`.