### PR TITLE
SSO: Introduce 'mercator.sso.back_url' filter

### DIFF
--- a/sso.php
+++ b/sso.php
@@ -546,10 +546,19 @@ function handle_login_response() {
 		exit;
 	}
 
+	/**
+	 * Filters the back URL used when the user gets redirected after SSO.
+	 *
+	 * @since 1.0.x
+	 *
+	 * @param string $back Redirect URL.
+	 */
+	$back = apply_filters( 'mercator.sso.back_url', $token['back'] );
+
 	// Verified, let's boop.
 	if ( is_user_logged_in() && get_current_user_id() === $token['user'] ) {
 		// Nothing to do.
-		wp_redirect( $token['back'] );
+		wp_redirect( $back );
 		exit;
 	}
 
@@ -557,6 +566,6 @@ function handle_login_response() {
 	wp_set_auth_cookie( $token['user'], true );
 
 	// Logged in, return to sender.
-	wp_redirect( $token['back'] );
+	wp_redirect( $back );
 	exit;
 }


### PR DESCRIPTION
This PR introduces the `'mercator.sso.back_url'` filter. This is handy for plugin developers to redirect users to a different page after SSO is done.

I do see that there is a `v2` branch. If you'd like me to add a PR from that branch as a base, let me know.