### PR TITLE
Fix docblock with correct return types

### DIFF
--- a/class-mapping.php
+++ b/class-mapping.php
@@ -273,7 +273,7 @@ class Mapping {
 	 * Convert list of data to Mapping instances
 	 *
 	 * @param stdClass[] $data Raw mapping rows
-	 * @return Mapping[]
+	 * @return Mapping[] Array of Mapping objects
 	 */
 	protected static function to_instances( $data ) {
 		return array_map( array( get_called_class(), 'to_instance' ), $data );
@@ -315,7 +315,7 @@ class Mapping {
 	 * Get mapping by site ID
 	 *
 	 * @param int|stdClass $site Site ID, or site object from {@see get_blog_details}
-	 * @return Mapping|WP_Error|null Mapping on success, WP_Error if error occurred, or null if no mapping found
+	 * @return Mapping[]|WP_Error|null Array of Mapping objects on success, WP_Error if error occurred, or null if no mapping found
 	 */
 	public static function get_by_site( $site ) {
 		global $wpdb;


### PR DESCRIPTION
I'd like to suggest fixing the docblocks to be able to use **phpstan**, which is complaining about the incorrect return types.

> Argument of an invalid type Mercator\Mapping supplied for foreach, only iterables are supported.

This PR would allow the *Mercator* function `get_by_site()` to be used like this and without phpstan errors:

```php
$mappings = Mercator\Mapping::get_by_site( $site_id );

// Check if there are mappings for the site.
if ( empty( $mappings ) || is_wp_error( $mappings ) ) {
	return '';
}

foreach ( $mappings as $mapping ) {
	// Do something nice here.
}
```
